### PR TITLE
setting web config to no-log, cf h

### DIFF
--- a/tasks/web-install.yml
+++ b/tasks/web-install.yml
@@ -54,6 +54,7 @@
 
 - name: omero web | configuration script
   become: yes
+  no_log: true
   template:
     dest: "{{ omero_web_basedir }}/config/omero-web-config-update.sh"
     force: yes
@@ -65,6 +66,7 @@
 
 - name: omero web | configuration 00-omero-web.omero
   become: yes
+  no_log: true
   template:
     dest: "{{ omero_web_basedir }}/config/00-omero-web.omero"
     force: yes


### PR DESCRIPTION
This PR stops the role from outputting potentially sensitive configuration at the cli where Ansible is run from. (I generally log this output, and don't want e.g. public-user password appearing in log files).

Tested on https://github.com/openmicroscopy/management_tools/pull/352#issuecomment-291193765 and previous runs of this role for `ns-web`. 

You can review the output of https://github.com/openmicroscopy/management_tools/files/890668/ns-web-provision_20170403-160536Z.txt (linked to on the pr linked above) to see that despite the command `ansible-playbook --diff` being run,  the web config changed, but no diff is recorded:

```
RUNNING HANDLER [openmicroscopy.omero-web : omero-web rewrite omero-web configuration] ***
changed: [ns-web.openmicroscopy.org]

RUNNING HANDLER [openmicroscopy.omero-web : omero-web restart omero-web] *******
changed: [ns-web.openmicroscopy.org]
```

cf 
https://dantehranian.wordpress.com/2015/07/24/managing-secrets-with-ansible-vault-the-missing-guide-part-1-of-2/

Note: ansible-role-omero-server could probably do with this as well.