### PR TITLE
Change the system user to omero-web

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ services:
   - docker
 
 install:
-  - pip install ansible docker 'molecule<1.22'
+  # Bug in 2.2.2: https://github.com/ansible/ansible/issues/23016
+  - pip install ansible==2.2.1.0 docker 'molecule<1.22'
 
 script:
   - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ services:
   - docker
 
 install:
-  # Bug in 2.2.2: https://github.com/ansible/ansible/issues/23016
-  - pip install ansible==2.2.1.0 docker 'molecule<1.22'
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ OMERO.web version and installation.
   This is a workaround for the inability to check for the latest version when `omero_web_release: latest`.
   It may be removed in future.
 - `omero_web_ice_version`: The ice version.
-- `omero_web_system_user`: OMERO.web system user, default `omeroweb`.
+- `omero_web_system_user`: OMERO.web system user, default `omero-web`.
 - `omero_web_systemd_setup`: Create and start the `omero-web` systemd service, default `True`
 
 OMERO.web configuration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ omero_web_upgrade: False
 omero_web_ice_version: "3.6"
 
 # OMERO.web system user
-omero_web_system_user: omeroweb
+omero_web_system_user: omero-web
 
 # Setup systemd services
 omero_web_systemd_setup: True

--- a/tests/test_omero-default.py
+++ b/tests/test_omero-default.py
@@ -7,7 +7,7 @@ OMERO = '/opt/omero/web/OMERO.web/bin/omero'
 
 
 def test_omero_web_config(Command, Sudo):
-    with Sudo('omeroweb'):
+    with Sudo('omero-web'):
         cfg = Command.check_output("%s config get" % OMERO)
     assert cfg == (
         'omero.web.server_list=[["localhost", 12345, "molecule-test"]]')


### PR DESCRIPTION
- Change the system user to `omero-web` (requested on an issue in a private repo)
- Add an ansible workaround
- Use https://pypi.python.org/pypi/ome-ansible-molecule-dependencies/ for bundling dependencies