### PR TITLE
Bump omero-marshal dependencies in omero-web role

### DIFF
--- a/tasks/web-dependencies.yml
+++ b/tasks/web-dependencies.yml
@@ -15,7 +15,7 @@
     - "django-pipeline>=1.3,<1.4"
     - "django-redis>=4.4"
     - "gunicorn>=19.3"
-    - "omero-marshal==0.5.0"
+    - "omero-marshal>=0.5.1,<0.6"
     state: present
     virtualenv: "{{ omero_web_basedir }}/venv"
     virtualenv_site_packages: yes


### PR DESCRIPTION
For OMERO 5.3.x, any non-breaking 0.5.x omero-marshal version should be valid. The dependency sets 0.5.1 as the minimum as it contains a patch required for any OMERO version greater than 5.3.1