### PR TITLE
Install downloaded OMERO.web bundled requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ OMERO Web
 Installs and configures OMERO.web and Nginx.
 Uses a conf.d style configuration directory for managing the OMERO.web configuration.
 
+This role supports installation of OMERO.web 5.3+, and upgrades of existing OMERO.web 5.2 installations to 5.3+.
+
 
 Role Variables
 --------------

--- a/tasks/web-dependencies.yml
+++ b/tasks/web-dependencies.yml
@@ -1,25 +1,14 @@
 ---
-# Dependencies for OMERO.web
+# System dependencies for OMERO.web
+# Additional requirements will be installed after OMERO.web has been
+# downloaded since it comes with its own requirements.txt
+# See web-install.yml
 
 - name: omero web | install python redis package
   become: yes
   yum:
     name: python-redis
     state: present
-
-- name: omero web | setup virtualenv
-  become: yes
-  pip:
-    name:
-    - "django>=1.8,<1.9"
-    - "django-pipeline>=1.3,<1.4"
-    - "django-redis>=4.4"
-    - "gunicorn>=19.3"
-    - "omero-marshal>=0.5.1,<0.6"
-    state: present
-    virtualenv: "{{ omero_web_basedir }}/venv"
-    virtualenv_site_packages: yes
-
 
 # selinux
 

--- a/tasks/web-install.yml
+++ b/tasks/web-install.yml
@@ -90,3 +90,14 @@
   notify:
   - omero-web rewrite omero-web configuration
   - omero-web restart omero-web
+
+- name: omero web | setup virtualenv
+  become: yes
+  pip:
+    requirements: "{{ omero_web_basedir }}/OMERO.web/share/web/requirements-py27.txt"
+    state: present
+    virtualenv: "{{ omero_web_basedir }}/venv"
+    virtualenv_site_packages: yes
+  notify:
+  - omero-web rewrite omero-web configuration
+  - omero-web restart omero-web


### PR DESCRIPTION
For discussion alongside https://github.com/openmicroscopy/ansible-role-omero-web/pull/3

We've got the choice of either maintaining the web dependencies as in #3, or installing dependencies after downloading OMERO.web based on the bundled `OMERO.web/share/web/requirements-py27.txt` file. #3 means you know ahead of time what changes will be made, this has the advantage of not needing to maintain the dependencies but you won't know what Python dependencies will be installed until after OMERO.web has been updated.

This is a breaking change since older versions of OMERO.web don't have `share/web/requirements-py27.txt`. Use the older version of this role instead to install them (upgrades from older OMERO.web to current releases should work).