### PR TITLE
Use upstream openmicroscopy.omero-common

### DIFF
--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,5 +1,4 @@
-- name: openmicroscopy.omero-common
-  src:  https://github.com/openmicroscopy/ansible-role-omero-common.git
+- src: openmicroscopy.omero-common
 - name: openmicroscopy.omego
   src:  https://github.com/openmicroscopy/ansible-role-omego.git
 - src: openmicroscopy.basedeps


### PR DESCRIPTION
Following ansible/galaxy-issues#259, using GitHub should no longer be required.