### PR TITLE
Ensure config dict keys are sorted for idempotence

### DIFF
--- a/templates/00-omero-web-omero.j2
+++ b/templates/00-omero-web-omero.j2
@@ -5,7 +5,7 @@ config drop default
 {% endif %}
 
 # Additional custom options
-{% for key in omero_web_config_set %}
+{% for key in (omero_web_config_set | sort) %}
 config set -- {{ key | quote }} {{
   ((omero_web_config_set[key] | string) == omero_web_config_set[key]) |
   ternary(omero_web_config_set[key], omero_web_config_set[key] | to_json) |


### PR DESCRIPTION
Python dict keys are unordered. This change ensures the addition or removal of keys will not change the order of existing configuration lines. If this is run on an existing server the config lines will be reordered.

Related: https://github.com/openmicroscopy/ansible-role-omero-server/issues/25

Minor fix, tag `1.0.2`
  
  