### PR TITLE
Upgrade OMERO.web automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ Role Variables
 All variables are optional, see `defaults/main.yml` for the full list
 
 OMERO.web version and installation.
-- `omero_web_release`: The version of OMERO.web to install, default `latest`
-- `omero_web_upgrade`: Upgrade OMERO.web if the current version does not match `omero_web_release`.
-  This is a workaround for the inability to check for the latest version when `omero_web_release: latest`.
-  It may be removed in future.
+- `omero_web_release`: The OMERO.web release, e.g. `5.4.2`.
+  The default is `present` which will install the latest version if web is not already installed, but will not modify an existing web.
+  Use `latest` to automatically upgrade when a new version is released.
 - `omero_web_ice_version`: The ice version.
 - `omero_web_system_user`: OMERO.web system user, default `omero-web`.
 - `omero_web_systemd_setup`: Create and start the `omero-web` systemd service, default `True`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,7 @@
 # defaults for omero-web
 
 # WARNING: This will currently always attempt to update the server since the registry check is broken
-omero_web_release: latest
-
-# If True and server is already installed then upgrade to the version in
-# omero_server_release, otherwise don't upgrade an existing server.
-omero_web_upgrade: False
+omero_web_release: present
 
 # Ice version
 omero_web_ice_version: "3.6"
@@ -46,8 +42,18 @@ omero_web_omego: "{{ omero_common_basedir }}/omego/bin/omego"
 # Additional omego aguments passed to upgrade or install
 omero_web_omego_additional_args: ""
 
+# If True and web is already installed then upgrade to the version in
+# omero_web_release, otherwise don't upgrade an existing web.
+# This should not be needed if versions are correctly compared.
+omero_web_upgrade: True
+
+# DEVELOPMENT: Operator for comparing current-version against
+# omero_web_release, e.g. '!='. Default is to upgrade when
+# current-version < omero_web_release
+omero_web_checkupgrade_comparator: '<'
+
 omero_web_omego_options: >
-  --release {{ omero_web_release }}
+  --release {{ _omero_web_new_version }}
   --sym {{ omero_web_symlink }}
   --ice {{ omero_web_ice_version }}
   -qq

--- a/molecule.yml
+++ b/molecule.yml
@@ -31,6 +31,8 @@ docker:
 
 ansible:
   host_vars:
+    omero-web:
+      omero_web_release: latest
     omero-web-inactive:
       # This tests a hypothetical instance where systemd is inactive but might
       # be activated in future
@@ -38,6 +40,7 @@ ansible:
       # that will never have systemd, e.g. a simple docker container
       omero_web_systemd_start: False
       omero_web_setup_nginx: False
+      omero_web_release: present
 
 verifier:
   name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,5 +1,41 @@
----
+# Install 5.3 on both omero-web omero-web-inactive
+- hosts: all
 
+  pre_tasks:
+    # To test the upgrade process without breaking the idempotence check
+    # we need to add a flag so the first omero-web installation is
+    # only run once
+    - name: check whether omero-web has been installed at least once
+      stat:
+        path: /opt/omero/web/OMERO.web
+      register: molecule_test_omero_web_installed_1
+
+  roles:
+
+    - role: ansible-role-omero-web
+      omero_web_config_set:
+        omero.web.server_list:
+        - [localhost, 12345, molecule-test]
+      omero_web_release: "5.3"
+      when: not molecule_test_omero_web_installed_1.stat.exists
+
+  tasks:
+    - name: get omero-web version
+      become: yes
+      become_user: omero-web
+      command: /opt/omero/web/OMERO.web/bin/omero version
+      register: molecule_test_omero_web_version
+      changed_when: False
+
+    - name: check version
+      assert:
+        that: molecule_test_omero_web_version.stdout.startswith('5.3.')
+      when: not molecule_test_omero_web_installed_1.stat.exists
+
+# Attempt to upgrade
+# omero_web_release is defined in molecule.yml host_vars so:
+# - omero-web: latest: upgraded
+# - omero-web-inactive: present: unchanged at 5.3
 - hosts: all
   roles:
     - role: ansible-role-omero-web

--- a/tasks/web-install.yml
+++ b/tasks/web-install.yml
@@ -27,28 +27,54 @@
     msg: "OMERO.web found but unable to get version, you may have a corrupt installation"
     that: "not (omero_web_symlink_st.stat.exists and omero_web_version is undefined)"
 
+# Check whether an upgrade is available
+- name: omero web | get latest downloads url
+  uri:
+    url: https://downloads.openmicroscopy.org/latest/omero
+    method: HEAD
+  register: _omero_web_downloads_latest
+
+# omego supports --release "latest" but not "present"
+# It's easiest to lookup a concrete version and use this for all omego
+# operations instead
+- name: omero web | get latest version
+  set_fact:
+    _omero_web_new_version: "{{
+      (omero_web_release in ('latest', 'present')) | ternary(
+         _omero_web_downloads_latest.url.strip('/').split('/')[-1],
+         omero_web_release
+      )
+  }}"
+
 - name: omero web | checkupgrade
   set_fact:
-    omero_web_update_needed: >
-      {{ (not omero_web_symlink_st.stat.exists) or
-         (omero_web_version is not defined) or
-         (omero_web_version.stdout | default('') |
-           regex_replace('^([^-]+).*', '\\1') != omero_web_release) |
-         bool
-      }}
+    # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
+    # so this should work as expected
+    _omero_web_update_needed: "{{
+      omero_web_symlink_st.stat.exists and
+      (omero_web_version.stdout | version_compare(
+         _omero_web_new_version,
+         omero_web_checkupgrade_comparator))
+    }}"
 
 - debug:
-    msg: "OMERO.web upgrade needed?: {{ omero_web_update_needed }}"
+    msg: "Upgrade needed: {{ omero_web_version.stdout }} -> {{ omero_web_release }}"
+  when: _omero_web_update_needed
+
+- name: omero web | set upgrade flag
+  set_fact:
+    _omero_web_execute_upgrade: "{{
+      omero_web_upgrade and
+      _omero_web_update_needed and
+      (omero_web_release != 'present')
+    }}"
 
 - name: omero web | stop omero web
   become: yes
   service:
     name: omero-web
     state: stopped
-  when: >
-    (omero_web_systemd_setup and
-     omero_web_update_needed and
-     omero_web_upgrade)
+  when: omero_web_systemd_setup and _omero_web_execute_upgrade
   # Might not be installed
   ignore_errors: yes
 
@@ -84,9 +110,7 @@
     python
   args:
     chdir: "{{ omero_web_basedir }}"
-  when: >
-    omero_web_update_needed and
-    (not omero_web_symlink_st.stat.exists or omero_web_upgrade)
+  when: _omero_web_execute_upgrade or not omero_web_symlink_st.stat.exists
   notify:
   - omero-web rewrite omero-web configuration
   - omero-web restart omero-web

--- a/tests/test_omero-web-inactive.py
+++ b/tests/test_omero-web-inactive.py
@@ -3,6 +3,14 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('omero-web-inactive')
 
+OMERO = '/opt/omero/web/OMERO.web/bin/omero'
+
+
+def test_omero_version(Command, Sudo):
+    with Sudo('omero-web'):
+        ver = Command.check_output("%s version" % OMERO)
+    assert ver.startswith('5.3.')
+
 
 def test_nginx_not_configured(File):
     assert not File('/etc/nginx/conf.d/omero-web.conf').exists

--- a/tests/test_omero-web.py
+++ b/tests/test_omero-web.py
@@ -1,8 +1,21 @@
 import testinfra.utils.ansible_runner
 import pytest
+import re
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('omero-web')
+
+OMERO = '/opt/omero/web/OMERO.web/bin/omero'
+VERSION_PATTERN = re.compile('(\d+)\.(\d+)\.(\d+)-ice36-')
+
+
+def test_omero_version(Command, Sudo):
+    with Sudo('omero-web'):
+        ver = Command.check_output("%s version" % OMERO)
+    m = VERSION_PATTERN.match(ver)
+    assert m is not None
+    assert int(m.group(1)) >= 5
+    assert int(m.group(2)) > 3
 
 
 @pytest.mark.parametrize("name", ["omero-web", "nginx"])


### PR DESCRIPTION
`omero_web_upgrade` is now an internal variable that should never need to be set in normal usage since it is possible to determine whether an upgrade is needed by checking the latest version on downloads.
`omero_web_release`: can be set to `present`, `latest` or ` a fixed version
This matches the behaviour of the omero-server role