### PR TITLE
Always fetch latest uri even in check_mode

### DIFF
--- a/tasks/web-install.yml
+++ b/tasks/web-install.yml
@@ -33,6 +33,7 @@
     url: https://downloads.openmicroscopy.org/latest/omero
     method: HEAD
   register: _omero_web_downloads_latest
+  check_mode: no
 
 # omego supports --release "latest" but not "present"
 # It's easiest to lookup a concrete version and use this for all omego


### PR DESCRIPTION
This ensures this role work in check-mode. This is the equivalent of https://github.com/openmicroscopy/ansible-role-omero-server/pull/22

Tag: `2.0.1`